### PR TITLE
docs: Fix title on the Graviton Builder documentation page

### DIFF
--- a/docs/builders/graviton-builder.md
+++ b/docs/builders/graviton-builder.md
@@ -1,4 +1,4 @@
-# GPU Builder
+# Graviton Builder
 
 The `GravitonBuilder` allows you to get started with a builder class to configure with required setup as you prepare a blueprint for setting up EKS cluster with Graviton worker nodes to run your ARM64 workloads.
 


### PR DESCRIPTION
Fix title on the Graviton Builder documentation page.